### PR TITLE
Added config option for elasticsearch protocol

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -14,3 +14,4 @@ var docType = "type"; //Ex: tweet
 var maxResultsSize = 10;
 var host = "localhost"; //Ex: http://ec2-123-aws.com
 var port = 9200;
+var protocol = ""; //Default: same as browser

--- a/js/services.js
+++ b/js/services.js
@@ -13,8 +13,9 @@ Calaca.factory('calacaService', ['$q', 'esFactory', '$location', function($q, el
 
     //Set defaults if host and port aren't configured
     var esHost = (host.length > 0 ) ? host : $location.host();
+    var esProtocol = (protocol.length > 0 ) ? protocol : $location.protocol();
 
-    var client = elasticsearch({ host: esHost + ":" + port });
+    var client = elasticsearch({ host: esProtocol + '://' + esHost + ":" + port });
 
     var search = function(term, mode, offset){
 


### PR DESCRIPTION
Added config option for specifying the elasticsearch service's protocol.

E.g. My instance is behind HTTPS which allows me to switch it.

By default uses whatever Calaca has been accessed with.
